### PR TITLE
Breaking up path

### DIFF
--- a/_/path.zsh
+++ b/_/path.zsh
@@ -1,0 +1,4 @@
+# These are basic bins that need to be loaded first, so
+# they can be overridden by applications later
+export PATH=/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:$PATH
+

--- a/git/path.zsh
+++ b/git/path.zsh
@@ -1,0 +1,3 @@
+export PATH=/usr/local/git/bin:$PATH
+export PATH=~/.dotfiles/git-cmd:$PATH
+


### PR DESCRIPTION
setting my by sourcing it in the zsh folder made it load last and so
having things like `/usr/bin:/usr/local/bin` loaded last makes it hard
to override by applications. So I'm moving that to a folder called `_`
so it will load first.

And then topic specific paths will get their own files, like in the case
of this git/path.zsh